### PR TITLE
Change link in header

### DIFF
--- a/src/components/App.vue
+++ b/src/components/App.vue
@@ -8,7 +8,7 @@
       <h1><a href="#/">Hacker News</a></h1>
       <span class="source">
         Built with <a href="http://vuejs.org" target="_blank">Vue.js</a> |
-        <a href="https://github.com/yyx990803/vue-hackernews" target="_blank">Source</a>
+        <a href="https://github.com/vuejs/vue-hackernews" target="_blank">Source</a>
       </span>
     </div>
     <!-- main view -->


### PR DESCRIPTION
Changed yyx990803 to vuejs in the link to the GitHub repository, it redirects there anyway but it might not in the future.
