### PR TITLE
Remove 'keep-alive' property

### DIFF
--- a/src/components/App.vue
+++ b/src/components/App.vue
@@ -14,7 +14,6 @@
     <!-- main view -->
     <router-view
       class="view"
-      keep-alive
       transition
       transition-mode="out-in">
     </router-view>


### PR DESCRIPTION
The 'keep-alive' property causes the `destroyed()` method of each VueView to never be called thus listeners are never removed!
